### PR TITLE
make_dir_table: calculate length to recurse from outdir and dir_levels

### DIFF
--- a/R/make_dir_table.R
+++ b/R/make_dir_table.R
@@ -49,7 +49,7 @@ make_dir_table <- function(out_dir,
 
   use_levels <- dir_levels[dir_levels <= return_level]
 
-  recurse_levels <- length(dir_levels) - length(stringr::str_split(out_dir, pattern = "\\/")[[1]])
+  recurse_levels <- length(dir_levels) - length(stringr::str_split(gsub(pattern = "/app/", replacement = "app/", x = out_dir), pattern = "\\/")[[1]])
 
   folders <- fs::dir_ls(out_dir, recurse = recurse_levels, type = "directory") |>
     gsub(pattern = "/app/", replacement = "app/") #to handle sol server 'drive' naming

--- a/R/make_dir_table.R
+++ b/R/make_dir_table.R
@@ -49,7 +49,9 @@ make_dir_table <- function(out_dir,
 
   use_levels <- dir_levels[dir_levels <= return_level]
 
-  folders <- fs::dir_ls(out_dir, recurse = 2, type = "directory") |>
+  recurse_levels <- length(dir_levels) - length(stringr::str_split(out_dir, pattern = "\\/")[[1]])
+
+  folders <- fs::dir_ls(out_dir, recurse = recurse_levels, type = "directory") |>
     gsub(pattern = "/app/", replacement = "app/") #to handle sol server 'drive' naming
 
   res <- folders |>


### PR DESCRIPTION
I think this generalises for the situation I'm trying to display in envSDMs_test? Previously I was getting an error saying the last level of dir_levels couldn't be found (as dir_ls was hardcoded to recurse to `2`)